### PR TITLE
Remove render thread stalls from the XR depth pipeline

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -117,7 +117,8 @@ android {
             resValue "string", "app_label_root", "Moonlight XR (Root Debug)"
 
             minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'),
+                    'proguard-rules.pro', 'proguard-rules-debug.pro'
         }
         release {
             // This fork ships under its own applicationId, so the unofficial

--- a/app/proguard-rules-debug.pro
+++ b/app/proguard-rules-debug.pro
@@ -1,0 +1,9 @@
+# Debug only, alongside proguard-rules.pro.
+#
+# The debug build used to get this by way of getDefaultProguardFile(
+# 'proguard-android.txt'), which AGP 9 no longer accepts precisely because it
+# carries this flag. Keeping it here preserves what the debug build always
+# did — shrink and obfuscate, but skip R8's optimization passes, so a debug
+# build stays quick and its stack traces stay close to the source — without
+# touching the release build, which has always optimized.
+-dontoptimize

--- a/app/src/main/java/com/limelight/binding/audio/AndroidAudioRenderer.java
+++ b/app/src/main/java/com/limelight/binding/audio/AndroidAudioRenderer.java
@@ -8,6 +8,7 @@ import android.media.AudioManager;
 import android.media.AudioTrack;
 import android.media.audiofx.AudioEffect;
 import android.os.Build;
+import android.os.Process;
 
 import com.limelight.LimeLog;
 import com.limelight.nvstream.av.audio.AudioRenderer;
@@ -19,6 +20,13 @@ public class AndroidAudioRenderer implements AudioRenderer {
     private final boolean enableAudioFx;
 
     private AudioTrack track;
+    // Which thread the priority bump below has already been applied to, since
+    // setThreadPriority only affects the caller and this is called once per
+    // audio frame. Keyed on the tid rather than a plain flag: if the audio
+    // thread is ever recreated mid stream, a flag would silently leave the
+    // replacement at its default priority, which is exactly the condition the
+    // bump exists to prevent and would be invisible.
+    private int prioritizedAudioTid;
 
     public AndroidAudioRenderer(Context context, boolean enableAudioFx) {
         this.context = context;
@@ -187,6 +195,17 @@ public class AndroidAudioRenderer implements AudioRenderer {
 
     @Override
     public void playDecodedAudio(short[] audioData) {
+        // This runs on the native pthread that decodes and submits audio
+        // samples, which lives in moonlight-common-c and so cannot be touched
+        // from Java before it starts. The first sample to arrive on it is as
+        // early as this code can reach it, and one raised priority covers
+        // every sample after, so only the tid check is paid per frame.
+        int tid = Process.myTid();
+        if (prioritizedAudioTid != tid) {
+            Process.setThreadPriority(Process.THREAD_PRIORITY_AUDIO);
+            prioritizedAudioTid = tid;
+        }
+
         // Only queue up to 40 ms of pending audio data in addition to what AudioTrack is buffering for us.
         if (MoonBridge.getPendingAudioDuration() < 40) {
             // This will block until the write is completed. That can cause a backlog

--- a/app/src/main/java/com/limelight/binding/video/XrRenderer.java
+++ b/app/src/main/java/com/limelight/binding/video/XrRenderer.java
@@ -111,6 +111,10 @@ public class XrRenderer implements SurfaceTexture.OnFrameAvailableListener {
     private volatile float lastInferenceMs;
     private volatile float lastDepthAgeMs;
     private volatile int lastDepthSkips;
+    // Set from the frame loop, read from setOverlayText() on the reporting
+    // thread, same as the three above: without this the adaptive cadence
+    // controller would be adjusting something nobody could observe.
+    private volatile int lastEffectiveCadence;
 
     // Controller pointer. The native side does the ray maths and hands back a
     // hit point and a button mask, this side turns that into host events.
@@ -441,7 +445,8 @@ public class XrRenderer implements SurfaceTexture.OnFrameAvailableListener {
     private native void nativeEndFrame(long ctx, boolean newFrame, float[] texMatrix,
                                        float distance, float quadWidth, float curvature,
                                        boolean headLocked, float separation, boolean eyeSwap,
-                                       boolean passthrough);
+                                       boolean passthrough, int cadenceLowerBound);
+    private native int nativeGetAdaptiveCadence(long ctx);
     private native void nativeUpdateInput(long ctx, float distance, float quadWidth,
                                           float curvature, boolean headLocked,
                                           boolean pointerEnabled, boolean gazeEnabled,
@@ -703,7 +708,10 @@ public class XrRenderer implements SurfaceTexture.OnFrameAvailableListener {
         boolean eyeSwap = prefs.vrEyeSwap;
         boolean pointer = prefs.vrPointer;
         boolean gaze = prefs.vrGaze;
-        int cadence = Math.max(1, prefs.vrInferenceCadence);
+        // The floor the adaptive controller is allowed to work from: it may
+        // only ever make inference cheaper than this, never dearer, since
+        // this is the quality the user actually asked for.
+        int userCadence = Math.max(1, prefs.vrInferenceCadence);
 
         long ageFrames = 0, ageNs = 0, ageSamples = 0, worstAgeNs = 0;
 
@@ -733,7 +741,11 @@ public class XrRenderer implements SurfaceTexture.OnFrameAvailableListener {
                 surfaceTexture.getTransformMatrix(texMatrix);
 
                 if (depthReady) {
-                    if ((videoFrameIndex % cadence) == 0) {
+                    int recommendation = nativeGetAdaptiveCadence(nativeCtx);
+                    int effectiveCadence = Math.max(userCadence,
+                            recommendation > 0 ? recommendation : userCadence);
+                    lastEffectiveCadence = effectiveCadence;
+                    if ((videoFrameIndex % effectiveCadence) == 0) {
                         handOffDepthFrame();
                     }
                     if (publishedFrameNs != 0) {
@@ -827,7 +839,7 @@ public class XrRenderer implements SurfaceTexture.OnFrameAvailableListener {
             }
 
             nativeEndFrame(nativeCtx, newFrame, texMatrix, distance, quadWidth, curvature,
-                    headLocked, separation, eyeSwap, passthroughOn);
+                    headLocked, separation, eyeSwap, passthroughOn, userCadence);
         }
     }
 
@@ -2371,6 +2383,7 @@ public class XrRenderer implements SurfaceTexture.OnFrameAvailableListener {
             sb.append('\n').append(String.format("Depth inference: %.1f ms", lastInferenceMs));
             sb.append('\n').append(String.format("Depth age: %.0f ms", lastDepthAgeMs));
             sb.append('\n').append("Depth frames skipped: ").append(lastDepthSkips);
+            sb.append('\n').append("Cadence: ").append(lastEffectiveCadence);
         }
         return sb.toString();
     }

--- a/app/src/main/java/com/limelight/binding/video/XrRenderer.java
+++ b/app/src/main/java/com/limelight/binding/video/XrRenderer.java
@@ -433,6 +433,7 @@ public class XrRenderer implements SurfaceTexture.OnFrameAvailableListener {
     private native ByteBuffer nativeGetModelInput(long ctx);
     private native ByteBuffer nativeGetModelOutput(long ctx);
     private native long nativeCaptureDepthInput(long ctx, float[] texMatrix);
+    private native long nativeFinishDepthCapture(long ctx);
     private native long nativeUploadDepth(long ctx);
     private native boolean nativeBindDepthContext(long ctx);
     private native void nativeUnbindDepthContext(long ctx);
@@ -631,6 +632,9 @@ public class XrRenderer implements SurfaceTexture.OnFrameAvailableListener {
 
             long start = System.nanoTime();
             long upload = 0;
+            // The render thread only queued the readback; this is where it is
+            // waited on and turned into modelInput, which estimate() reads
+            long finish = nativeFinishDepthCapture(nativeCtx);
             boolean ok = source.estimate();
             if (ok) {
                 upload = nativeUploadDepth(nativeCtx);
@@ -648,7 +652,7 @@ public class XrRenderer implements SurfaceTexture.OnFrameAvailableListener {
                 continue;
             }
 
-            captureNs += lastCaptureNs;
+            captureNs += lastCaptureNs + finish;
             inferenceNs += (long)(source.getLastInferenceMs() * 1000000.0f);
             lastInferenceMs = source.getLastInferenceMs();
             uploadNs += upload;

--- a/app/src/main/java/com/limelight/binding/video/XrRenderer.java
+++ b/app/src/main/java/com/limelight/binding/video/XrRenderer.java
@@ -16,6 +16,7 @@ import android.graphics.RectF;
 import android.graphics.Shader;
 import android.graphics.SurfaceTexture;
 import android.graphics.Typeface;
+import android.os.Process;
 import android.preference.PreferenceManager;
 import android.view.Surface;
 
@@ -472,6 +473,13 @@ public class XrRenderer implements SurfaceTexture.OnFrameAvailableListener {
         renderThread = new Thread() {
             @Override
             public void run() {
+                // Submission has to land inside the compositor's frame window,
+                // so this thread cannot sit behind the decoder or the depth
+                // worker the way an unprioritized thread would. Thread.setPriority()
+                // only changes the JVM's bookkeeping, not the Linux scheduler,
+                // so the real syscall goes through Process.
+                Process.setThreadPriority(Process.THREAD_PRIORITY_URGENT_DISPLAY);
+
                 // Before init, so everything the session setup finds ends up
                 // in the log too
                 nativeSetFileLog(FileLog.getLogPath(), FileLog.getLevel());
@@ -557,6 +565,12 @@ public class XrRenderer implements SurfaceTexture.OnFrameAvailableListener {
         depthThread = new Thread() {
             @Override
             public void run() {
+                // Above the default so a busy system does not starve inference
+                // behind everything else, but deliberately not BACKGROUND:
+                // that cpuset is little cores only on this SoC and would make
+                // the wall-clock cost of a model run worse, not better.
+                Process.setThreadPriority(Process.THREAD_PRIORITY_DEFAULT + 5);
+
                 if (!nativeBindDepthContext(nativeCtx)) {
                     return;
                 }

--- a/app/src/main/jni/xr-renderer/xr_renderer.c
+++ b/app/src/main/jni/xr-renderer/xr_renderer.c
@@ -16,6 +16,7 @@
 #include <sys/stat.h>
 #include <time.h>
 #include <math.h>
+#include <stdatomic.h>
 
 #include <android/log.h>
 #include <sys/system_properties.h>
@@ -605,6 +606,17 @@ static void xrLog(int prio, const char* fmt, ...) {
 
 #define DEPTH_TEX_SIZE 256
 
+// Three rather than two: the depth thread advances through them in a fixed
+// rotation, so a slot it is about to overwrite was last handed to the render
+// thread a full rotation ago rather than one. One inference (>= 13.5 ms
+// measured, MidasDepthSource.java:40) dwarfs anything the render thread
+// could still have in flight from that slot by then.
+#define DEPTH_TEX_COUNT 3
+
+// Generous on purpose: the depth thread has no per frame deadline, and a
+// short timeout here would only trade a hung capture for a corrupt one.
+#define CAPTURE_FENCE_TIMEOUT_NS 500000000ull
+
 // Pinned headers may predate the extension, values from the OpenXR registry
 #ifndef XR_FB_composition_layer_settings
 #define XR_FB_composition_layer_settings 1
@@ -735,10 +747,27 @@ typedef struct {
     // wide and each eye gets its own warped copy of the frame
     int stereoMode;
     int depthDebug;
-    // Double buffered: the frame loop samples one while the depth thread
-    // writes the other, so neither ever waits on the other
-    GLuint depthTextures[2];
+    // Triple buffered: the frame loop samples one slot while the depth
+    // thread rotates through the rest, so neither ever blocks on the other.
+    GLuint depthTextures[DEPTH_TEX_COUNT];
+    // Written only by the render thread, which is the only reader that
+    // matters for ordering here, so a plain volatile store is enough.
     volatile int depthReadIndex;
+    // Written only by the depth thread: the slot its next upload will
+    // target. Read only by that same thread, so it needs no synchronization
+    // at all.
+    int depthWriteIndex;
+    // Published by the depth thread together with the fence for that slot
+    // (nativeUploadDepth), and adopted by the render thread once it notices
+    // a new value (renderVideoFrame). Release/acquire on this single word is
+    // what guarantees the render thread never observes the index before the
+    // depthFences store that has to be visible along with it — two separate
+    // plain stores would not carry that ordering.
+    atomic_int depthStagedIndex;
+    // One fence per slot, non-NULL exactly while nothing has yet waited on
+    // it. Set by the depth thread right after the upload it guards, cleared
+    // by whichever render-thread call site first samples that slot.
+    GLsync depthFences[DEPTH_TEX_COUNT];
 
     // Second context in the same share group for the depth thread. Inference
     // takes longer than a display frame, so it cannot run on the frame loop
@@ -752,7 +781,19 @@ typedef struct {
     GLint downscaleTexMatrixUniform;
     GLuint downscaleTexture;
     GLuint downscaleFbo;
-    unsigned char* readbackBuf;
+    // Pixel pack buffers the downscale draw reads back into asynchronously:
+    // glReadPixels with one of these bound returns as soon as the transfer
+    // is queued rather than blocking the render thread for it. Two, ping
+    // ponged, though the handoff guard in handOffDepthFrame() means only one
+    // is ever in flight — the spare is headroom, not load-bearing.
+    GLuint depthPbos[2];
+    // Which of the two the most recent capture targeted, and the fence that
+    // guards reading it back. Both are written on the render thread and read
+    // on the depth thread with no atomics: the Java monitor around
+    // depthPending (handOffDepthFrame / runDepthLoop) already carries them
+    // across, the same way captureFrameIndex and captureFrameNs do.
+    int captureIndex;
+    GLsync captureFences[2];
     float* modelInput;
     float* modelOutput;
     unsigned char* depthUploadBuf;
@@ -2157,7 +2198,7 @@ static void fillSyntheticDepth(XrCtx* ctx) {
         }
     }
 
-    for (int i = 0; i < 2; i++) {
+    for (int i = 0; i < DEPTH_TEX_COUNT; i++) {
         glBindTexture(GL_TEXTURE_2D, ctx->depthTextures[i]);
         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, n, n, 0, GL_RGBA, GL_UNSIGNED_BYTE, buf);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
@@ -2381,7 +2422,21 @@ static int initDepthModel(XrCtx* ctx) {
         return 0;
     }
 
-    ctx->readbackBuf = malloc((size_t)n * n * 4);
+    // Slot 0 is what fillSyntheticDepth and depthReadIndex both start on, so
+    // the first real upload has to land somewhere else
+    ctx->depthWriteIndex = 1;
+    atomic_init(&ctx->depthStagedIndex, 0);
+
+    // Storage only, no data: each capture targets one with glReadPixels and
+    // the depth thread later maps it, so nothing is ever uploaded from the
+    // client side here
+    glGenBuffers(2, ctx->depthPbos);
+    for (int i = 0; i < 2; i++) {
+        glBindBuffer(GL_PIXEL_PACK_BUFFER, ctx->depthPbos[i]);
+        glBufferData(GL_PIXEL_PACK_BUFFER, (GLsizeiptr)n * n * 4, NULL, GL_STREAM_READ);
+    }
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+
     ctx->modelInput = malloc((size_t)n * n * 3 * sizeof(float));
     ctx->modelOutput = malloc((size_t)n * n * sizeof(float));
     ctx->depthUploadBuf = malloc((size_t)n * n * 4);
@@ -2389,7 +2444,7 @@ static int initDepthModel(XrCtx* ctx) {
     ctx->depthLow = malloc((size_t)n * n * sizeof(float));
     ctx->depthScratch = malloc((size_t)n * n * sizeof(float));
     ctx->depthColSums = malloc((size_t)n * sizeof(float));
-    if (ctx->readbackBuf == NULL || ctx->modelInput == NULL || ctx->modelOutput == NULL ||
+    if (ctx->modelInput == NULL || ctx->modelOutput == NULL ||
             ctx->depthUploadBuf == NULL || ctx->depthEma == NULL ||
             ctx->depthLow == NULL || ctx->depthScratch == NULL ||
             ctx->depthColSums == NULL) {
@@ -2444,7 +2499,7 @@ static int initGl(XrCtx* ctx) {
     glUniform1f(glGetUniformLocation(ctx->program, "u_showDepth"),
                 ctx->depthDebug ? 1.0f : 0.0f);
 
-    glGenTextures(2, ctx->depthTextures);
+    glGenTextures(DEPTH_TEX_COUNT, ctx->depthTextures);
     fillSyntheticDepth(ctx);
 
     glGenTextures(1, &ctx->oesTexture);
@@ -5064,7 +5119,24 @@ static void destroyXrInput(XrCtx* ctx) {
 static void destroyCtx(JNIEnv* env, XrCtx* ctx) {
     destroyXrInput(ctx);
 
-    free(ctx->readbackBuf);
+    // The depth thread has already been joined by this point (nativeDestroy
+    // runs after stopDepthThread()), but a slot whose fence was never
+    // sampled again after being published — the stream stopped before the
+    // frame loop got back to it — would otherwise leak a sync object.
+    for (int i = 0; i < DEPTH_TEX_COUNT; i++) {
+        if (ctx->depthFences[i] != NULL) {
+            glDeleteSync(ctx->depthFences[i]);
+            ctx->depthFences[i] = NULL;
+        }
+    }
+    for (int i = 0; i < 2; i++) {
+        if (ctx->captureFences[i] != NULL) {
+            glDeleteSync(ctx->captureFences[i]);
+            ctx->captureFences[i] = NULL;
+        }
+    }
+    glDeleteBuffers(2, ctx->depthPbos);
+
     free(ctx->modelInput);
     free(ctx->modelOutput);
     free(ctx->depthUploadBuf);
@@ -5407,10 +5479,13 @@ Java_com_limelight_binding_video_XrRenderer_nativeGetModelOutput(JNIEnv* env, jo
                                        (jlong)DEPTH_TEX_SIZE * DEPTH_TEX_SIZE * sizeof(float));
 }
 
-// Draws the current frame into the downscale target and reads it back into
-// the model input buffer. Rows are flipped on the way: GL hands back the
-// bottom row first and the model wants the image the right way up, since
-// monocular depth leans heavily on which way is down.
+// Draws the current frame into the downscale target and queues an
+// asynchronous readback of it, rather than reading it back synchronously the
+// way this used to: with a pixel pack buffer bound, glReadPixels only queues
+// the transfer and returns immediately, instead of stalling this thread —
+// the render thread, which has a frame budget to keep — until the GPU
+// produces the pixels. nativeFinishDepthCapture(), on the depth thread, is
+// where that readback is actually waited on and turned into model input.
 JNIEXPORT jlong JNICALL
 Java_com_limelight_binding_video_XrRenderer_nativeCaptureDepthInput(JNIEnv* env, jobject thiz,
                                                                     jlong handle,
@@ -5439,18 +5514,88 @@ Java_com_limelight_binding_video_XrRenderer_nativeCaptureDepthInput(JNIEnv* env,
     glEnableVertexAttribArray(1);
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
-    glReadPixels(0, 0, n, n, GL_RGBA, GL_UNSIGNED_BYTE, ctx->readbackBuf);
+    // The handoff guard in handOffDepthFrame() means the depth thread has
+    // always finished with the other slot by the time a new capture reaches
+    // here, but ping ponging costs nothing and leaves room if that guard
+    // ever loosens.
+    int slot = 1 - ctx->captureIndex;
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, ctx->depthPbos[slot]);
+    glReadPixels(0, 0, n, n, GL_RGBA, GL_UNSIGNED_BYTE, (void*)0);
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
-    for (int y = 0; y < n; y++) {
-        const unsigned char* src = ctx->readbackBuf + (size_t)(n - 1 - y) * n * 4;
-        float* dst = ctx->modelInput + (size_t)y * n * 3;
-        for (int x = 0; x < n; x++) {
-            dst[x * 3 + 0] = src[x * 4 + 0] * (1.0f / 255.0f);
-            dst[x * 3 + 1] = src[x * 4 + 1] * (1.0f / 255.0f);
-            dst[x * 3 + 2] = src[x * 4 + 2] * (1.0f / 255.0f);
-        }
+    if (ctx->captureFences[slot] != NULL) {
+        // Only reachable if the handoff guard above was somehow bypassed; a
+        // fence nothing ever waited on would otherwise leak here
+        glDeleteSync(ctx->captureFences[slot]);
     }
+
+    // Fence first, flush second, and the order is the whole point: a flush
+    // only pushes out what is already in this context's queue, so flushing
+    // before the fence exists leaves the fence itself sitting unflushed. The
+    // depth thread waits on it from a different context and cannot flush it
+    // from there — GL_SYNC_FLUSH_COMMANDS_BIT only acts on the calling
+    // context — so it would block until this thread happened to flush for
+    // some unrelated reason, which is exactly the coupling the PBO is here
+    // to remove.
+    ctx->captureFences[slot] = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+    glFlush();
+    ctx->captureIndex = slot;
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+
+    return nowNs() - startNs;
+}
+
+// Companion to nativeCaptureDepthInput(): waits for that capture's readback
+// to actually land, then normalizes it into modelInput exactly as the old
+// synchronous path did, rows flipped for the same reason — GL hands back the
+// bottom row first and the model wants the image the right way up. Runs on
+// the depth thread, right before estimate() reads modelInput, which is what
+// keeps this ordered before it despite living on the same thread rather than
+// needing any synchronization of its own: this thread blocks here rather
+// than moving on, unlike the render thread that queued the transfer.
+JNIEXPORT jlong JNICALL
+Java_com_limelight_binding_video_XrRenderer_nativeFinishDepthCapture(JNIEnv* env, jobject thiz,
+                                                                     jlong handle) {
+    XrCtx* ctx = (XrCtx*)(intptr_t)handle;
+    const int n = DEPTH_TEX_SIZE;
+    long startNs = nowNs();
+    int slot = ctx->captureIndex;
+
+    GLsync fence = ctx->captureFences[slot];
+    if (fence != NULL) {
+        // Checked rather than discarded: on a timeout the map below still
+        // hands back a buffer, so the frame would be normalized from whatever
+        // the transfer had managed so far and the depth map would go subtly
+        // wrong with nothing in the log to say why. Half a second is long
+        // past anything a 256x256 readback can legitimately take, so this
+        // firing means the fence never landed, not that the GPU was busy.
+        GLenum waited = glClientWaitSync(fence, 0, CAPTURE_FENCE_TIMEOUT_NS);
+        if (waited == GL_TIMEOUT_EXPIRED) {
+            LOGW("depth capture: readback fence timed out, frame may be torn");
+        }
+        glDeleteSync(fence);
+        ctx->captureFences[slot] = NULL;
+    }
+
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, ctx->depthPbos[slot]);
+    const unsigned char* src = (const unsigned char*)glMapBufferRange(
+            GL_PIXEL_PACK_BUFFER, 0, (GLsizeiptr)n * n * 4, GL_MAP_READ_BIT);
+    if (src != NULL) {
+        for (int y = 0; y < n; y++) {
+            const unsigned char* row = src + (size_t)(n - 1 - y) * n * 4;
+            float* dst = ctx->modelInput + (size_t)y * n * 3;
+            for (int x = 0; x < n; x++) {
+                dst[x * 3 + 0] = row[x * 4 + 0] * (1.0f / 255.0f);
+                dst[x * 3 + 1] = row[x * 4 + 1] * (1.0f / 255.0f);
+                dst[x * 3 + 2] = row[x * 4 + 2] * (1.0f / 255.0f);
+            }
+        }
+        glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
+    }
+    else {
+        LOGW("depth capture: PBO map failed");
+    }
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
 
     return nowNs() - startNs;
 }
@@ -5600,10 +5745,13 @@ static void lowPass(const float* src, float* dst, float* scratch, float* colSums
 // so raw model flicker does not reach the eyes. The guide colour rides along
 // in RGB so the upsampling pass gets the exact frame the depth came from.
 //
-// Runs on the depth thread, writing whichever texture the frame loop is not
-// sampling, then publishing it. The finish is what makes the upload visible
-// to the other context, and costs nothing here since this thread has no
-// deadline.
+// Runs on the depth thread, writing the next slot in the fixed rotation
+// (never the one the frame loop is currently reading), then publishing it
+// behind a fence rather than the glFinish() this used to block on: a finish
+// stalls the calling thread until the GPU is idle, which cost nothing here
+// only because this thread has no deadline, and it is not what the frame
+// loop's context actually needs. What it needs is something it can wait on
+// itself, which is what the fence gives it.
 JNIEXPORT jlong JNICALL
 Java_com_limelight_binding_video_XrRenderer_nativeUploadDepth(JNIEnv* env, jobject thiz, jlong handle) {
     XrCtx* ctx = (XrCtx*)(intptr_t)handle;
@@ -5651,6 +5799,10 @@ Java_com_limelight_binding_video_XrRenderer_nativeUploadDepth(JNIEnv* env, jobje
                 DEPTH_LOWPASS_RADIUS);
     }
 
+    // modelInput here is the same buffer nativeFinishDepthCapture() filled
+    // just before estimate() ran, on this same thread earlier in this same
+    // depth loop iteration, so no separate synchronization is needed to read
+    // it below — only care not to reorder this ahead of that fill.
     for (int y = 0; y < n; y++) {
         const float* guide = ctx->modelInput + (size_t)(n - 1 - y) * n * 3;
         const float* ema = ctx->depthEma + (size_t)y * n;
@@ -5669,12 +5821,50 @@ Java_com_limelight_binding_video_XrRenderer_nativeUploadDepth(JNIEnv* env, jobje
         }
     }
 
-    int writeIndex = 1 - ctx->depthReadIndex;
+    int writeIndex = ctx->depthWriteIndex;
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, ctx->depthTextures[writeIndex]);
     glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, n, n, GL_RGBA, GL_UNSIGNED_BYTE, ctx->depthUploadBuf);
-    glFinish();
-    ctx->depthReadIndex = writeIndex;
+
+    if (ctx->depthFences[writeIndex] != NULL) {
+        // The render thread normally consumes a slot's fence the frame after
+        // it is published, so a live one here means it never got that far.
+        // That is not a rare path: renderVideoFrame() only runs when the
+        // runtime asks for a frame, while the capture that drives this thread
+        // runs on every decoded one, so anything that stops rendering without
+        // stopping the stream — the headset off the head, the app losing
+        // visibility — publishes slots nothing adopts, for as long as it
+        // lasts. Deleting is safe even against a wait already queued on the
+        // fence, since GL defers that until the wait is done, and skipping it
+        // would leak one sync object per publish.
+        glDeleteSync(ctx->depthFences[writeIndex]);
+    }
+
+    // A flush alone only promises the commands leave this context's queue; it
+    // does not promise a texture read in the render thread's context, which
+    // is a different context in the same share group, will see the result.
+    // The fence is what that other context can actually wait on, which a
+    // flush by itself is not.
+    //
+    // The fence has to be created before the flush, not after: a fence left
+    // unflushed in this context's queue is one the render thread's glWaitSync
+    // may never see satisfied, and it cannot flush this context on our
+    // behalf.
+    GLsync fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+    glFlush();
+    ctx->depthFences[writeIndex] = fence;
+
+    // Index and fence are published together with one release store, so the
+    // render thread can never see the new index before the fence write above
+    // that has to come with it. Two separate plain stores would not carry
+    // that guarantee.
+    atomic_store_explicit(&ctx->depthStagedIndex, writeIndex, memory_order_release);
+
+    // Always the next slot in fixed rotation, never a function of where the
+    // render thread currently is. That fixed rotation through three slots is
+    // what keeps this from ever landing on one the render thread could still
+    // have a draw call in flight against, see the DEPTH_TEX_COUNT comment.
+    ctx->depthWriteIndex = (writeIndex + 1) % DEPTH_TEX_COUNT;
 
     return nowNs() - startNs;
 }
@@ -6889,6 +7079,24 @@ static void writeCapture(XrCtx* ctx, const char* what, const void* data, size_t 
     LOGI("capture: %s %zu bytes", path, written);
 }
 
+// Waits, once, for the fence guarding ctx->depthTextures[ctx->depthReadIndex],
+// then discards it. A slot only carries a live fence between the depth
+// thread publishing it and the first render-thread call site that samples
+// it afterwards: once the wait is inserted into this context's command
+// queue, every later command in this context — including another sampling
+// site later in the same frame, or the same slot again next frame — is
+// already ordered behind the depth thread's upload by the GL queue itself,
+// so waiting on the same slot twice would mean waiting on a sync object
+// that has already been deleted.
+static void waitForDepthSlot(XrCtx* ctx) {
+    GLsync fence = ctx->depthFences[ctx->depthReadIndex];
+    if (fence != NULL) {
+        glWaitSync(fence, 0, GL_TIMEOUT_IGNORED);
+        glDeleteSync(fence);
+        ctx->depthFences[ctx->depthReadIndex] = NULL;
+    }
+}
+
 // Reads back the depth texture the warp actually sampled this frame, so the
 // captured warp can be reproduced exactly rather than approximately. Depth is
 // the alpha channel, the rgb alongside it is the guide.
@@ -6902,6 +7110,7 @@ static void writeCaptureDepthTexture(XrCtx* ctx) {
         return;
     }
 
+    waitForDepthSlot(ctx);
     GLuint fbo = 0;
     glGenFramebuffers(1, &fbo);
     glBindFramebuffer(GL_FRAMEBUFFER, fbo);
@@ -6938,6 +7147,7 @@ static void runUpsample(XrCtx* ctx, const float* texMatrix) {
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_EXTERNAL_OES, ctx->oesTexture);
     glActiveTexture(GL_TEXTURE1);
+    waitForDepthSlot(ctx);
     glBindTexture(GL_TEXTURE_2D, ctx->depthTextures[ctx->depthReadIndex]);
     glUniformMatrix4fv(ctx->upsampleTexMatrixUniform, 1, GL_FALSE, texMatrix);
     glUniform1f(ctx->upsampleSigmaUniform, ctx->upsampleSigmaR);
@@ -7926,6 +8136,16 @@ static void renderRoom(XrCtx* ctx) {
 }
 
 static void renderVideoFrame(XrCtx* ctx, const float* texMatrix, float separation) {
+    // Picks up whatever the depth thread most recently finished, once per
+    // frame and before anything below samples a depth slot. The fence that
+    // guards it is not waited on here — only a site that actually samples
+    // the texture needs to insert that wait — but by the time one does, the
+    // acquire below has already made the depth thread's fence store visible.
+    int stagedDepth = atomic_load_explicit(&ctx->depthStagedIndex, memory_order_acquire);
+    if (stagedDepth != ctx->depthReadIndex) {
+        ctx->depthReadIndex = stagedDepth;
+    }
+
     int upsampling = ctx->stereoMode == DEPTH_MODE_MODEL && ctx->upsampleEnabled;
     int occluding = upsampling && ctx->occlusionEnabled && separation > 0.0f;
 
@@ -8001,7 +8221,10 @@ static void renderVideoFrame(XrCtx* ctx, const float* texMatrix, float separatio
     glBindTexture(GL_TEXTURE_EXTERNAL_OES, ctx->oesTexture);
     glActiveTexture(GL_TEXTURE1);
     // Either the raw 256x256 map or the edge aware upsample of it. Both carry
-    // depth in alpha, so the warp shader does not care which it got.
+    // depth in alpha, so the warp shader does not care which it got. When
+    // upsampling is on, runUpsample() already waited on this slot's fence
+    // above; the call here is then a no-op, since the wait only happens once.
+    waitForDepthSlot(ctx);
     glBindTexture(GL_TEXTURE_2D, upsampling ? ctx->upsampleTexture
                                             : ctx->depthTextures[ctx->depthReadIndex]);
     glActiveTexture(GL_TEXTURE2);

--- a/app/src/main/jni/xr-renderer/xr_renderer.c
+++ b/app/src/main/jni/xr-renderer/xr_renderer.c
@@ -680,9 +680,29 @@ typedef struct XrCompositionLayerSettingsFB {
 #define PROP_ROOM_SCALE "debug.moonlight.roomscale"
 #define PROP_ROOM_DIM "debug.moonlight.roomdim"
 #define PROP_TB_SWAP "debug.moonlight.tbswap"
+// On by default: 0 pins the cadence to whatever the user chose, so the
+// adaptive controller can be A/B'd against a fixed value live
+#define PROP_ADAPTIVE_CADENCE "debug.moonlight.adaptivecadence"
 
 // Bins for the percentile search over the model output
 #define DEPTH_HIST_BINS 512
+
+// Tuning for the adaptive cadence controller. The window is the same order
+// as the existing poll periodicity (CAPTURE_POLL_FRAMES), the raise/lower
+// split is the deadband that keeps it from hunting between two cadences, and
+// the lockout holds a change long enough to see its effect before allowing
+// another.
+//
+// Both counts are in timer samples, not frames: the controller is fed from
+// the GPU timer's result block, which lands a sample every other frame at
+// best because of the two query slots, and drops the ones the driver hands
+// back implausible. Sixty samples is therefore well over a hundred frames,
+// which is deliberate but worth knowing before retuning it.
+#define CADENCE_WINDOW_SAMPLES 30
+#define CADENCE_RAISE_RATIO 0.80f
+#define CADENCE_LOWER_RATIO 0.55f
+#define CADENCE_LOCKOUT_SAMPLES 60
+#define CADENCE_MAX_RECOMMENDATION 8
 
 // Radius of the low pass that splits the depth map into an overall shape and
 // the local detail on top of it. About a tenth of the frame.
@@ -705,6 +725,24 @@ typedef struct {
     XrQuaternionf q;
     float dAngle;
 } EuroQuatState;
+
+// State for the adaptive cadence controller. Kept as its own struct rather
+// than loose fields on XrCtx so the decision logic below can take it by
+// pointer and stay a pure function of its inputs, which is what makes it
+// checkable without a headset: feed it synthetic samples and a budget and
+// see what it recommends.
+typedef struct {
+    // 64 bit regardless of ABI: long is 32 bit on the 32 bit ABIs this still
+    // builds for, where a window of 30 capped samples fits with only about a
+    // third to spare. CADENCE_WINDOW_SAMPLES is presented as a knob, so the
+    // headroom should not be something raising it silently spends.
+    int64_t windowTotalNs;
+    int windowSamples;
+    int samplesSinceChange;
+    // 0 means no recommendation has been formed yet, which the getter takes
+    // as "let the caller's own cadence stand"
+    int recommended;
+} CadenceController;
 
 typedef struct {
     JavaVM* vm;
@@ -991,6 +1029,10 @@ typedef struct {
     int sessionRunning;
     int exitRequested;
     XrTime predictedDisplayTime;
+    // The real per frame budget, from xrWaitFrame rather than a hardcoded
+    // 11.1 ms: this headset runs at 72, 90 or 120 Hz depending on the model
+    // and the refresh rate setting.
+    XrDuration displayPeriodNs;
     int shouldRender;
     int everRendered;
     // Frames submitted while focused. Passthrough waits for the first one, see
@@ -1359,6 +1401,13 @@ typedef struct {
     // disturb the logcat cadence
     long overlayGpuTotalNs;
     long overlayGpuSamples;
+
+    // Own accumulators again, for the same reason overlayGpuTotalNs is
+    // separate from gpuTotalNs: nativeGetWarpGpuMs() resets the overlay's
+    // pair on every read, and this must keep accumulating regardless of
+    // when the overlay happens to poll.
+    CadenceController cadenceCtrl;
+    int adaptiveCadenceEnabled;
 } XrCtx;
 
 typedef void (*PFNGENQUERIESEXT)(GLsizei, GLuint*);
@@ -5317,6 +5366,8 @@ Java_com_limelight_binding_video_XrRenderer_nativeInit(JNIEnv* env, jobject thiz
     ctx->upsampleSigmaR = 0.25f;
     ctx->upsampleEnabled = 1;
     ctx->occlusionEnabled = 1;
+    // On by default, matching the debug property that can turn it off live
+    ctx->adaptiveCadenceEnabled = 1;
     // Off until it earns its place in a blind comparison on device
     ctx->depthSharp = 0.0f;
     // Starts where the preference left it, and the panel can change it live
@@ -5894,6 +5945,11 @@ Java_com_limelight_binding_video_XrRenderer_nativeWaitBeginFrame(JNIEnv* env, jo
 
     ctx->predictedDisplayTime = frameState.predictedDisplayTime;
     ctx->shouldRender = frameState.shouldRender;
+    // The refresh rate is a headset and settings choice (72, 90 or 120 Hz,
+    // PreferenceConfiguration.java:118), not a constant, so the adaptive
+    // cadence controller needs the real per frame budget rather than a
+    // number that would only be right on one of them.
+    ctx->displayPeriodNs = frameState.predictedDisplayPeriod;
     return FRAME_RENDER;
 }
 
@@ -7044,6 +7100,7 @@ static void pollCaptureRequest(XrCtx* ctx) {
     // not a knob to sit on a slider.
     propScaled(PROP_ROOM_SCALE, &ctx->roomScaleOverride, 0.01f, 400);
     propScaled(PROP_ROOM_DIM, &ctx->roomDimOverride, 0.01f, 200);
+    propFlag(PROP_ADAPTIVE_CADENCE, &ctx->adaptiveCadenceEnabled);
 
     if (ctx->captureDir[0] == '\0') {
         return;
@@ -8135,7 +8192,68 @@ static void renderRoom(XrCtx* ctx) {
     ctx->roomRendered = 1;
 }
 
-static void renderVideoFrame(XrCtx* ctx, const float* texMatrix, float separation) {
+// The only real decision logic in the adaptive cadence path: everything else
+// around it is plumbing to get a GPU sample in and a cadence recommendation
+// out. Kept as a pure function of its inputs and the controller's own state,
+// with no GL calls and no reach into XrCtx, so it can be exercised with
+// synthetic samples and a synthetic budget without a headset.
+//
+// Hysteresis (raise above CADENCE_RAISE_RATIO of budget, lower only below
+// CADENCE_LOWER_RATIO) plus a lockout between changes is what keeps this
+// from hunting between two cadences and becoming a stutter source itself.
+// lowerBound is the floor the caller's own setting establishes: this only
+// ever recommends something at or above it, on the assumption that cheaper
+// means a higher cadence number (inference less often).
+//
+// Worth knowing before retuning the ratios: the sample is the warp window's
+// GPU time, which does not contain the inference. Contention with it shows up
+// only indirectly, as inflated warp time on the frames that overlap one, and
+// the mean dilutes that by roughly the cadence — at cadence 3 one frame in
+// three carries it. So the deadband is far too wide for this to oscillate
+// (it would take more added time on a contaminated frame than a whole frame
+// budget), but by the same arithmetic it will stay quiet unless the warp
+// itself is already close to the budget. If it never moves on device, that is
+// the reason, and the answer is a signal that sees missed frames directly,
+// not a narrower band here.
+static void adaptiveCadenceUpdate(CadenceController* c, long sampleNs, long budgetNs,
+                                  int lowerBound) {
+    c->windowTotalNs += sampleNs;
+    c->windowSamples++;
+    if (c->samplesSinceChange < CADENCE_LOCKOUT_SAMPLES) {
+        c->samplesSinceChange++;
+    }
+
+    if (c->windowSamples < CADENCE_WINDOW_SAMPLES) {
+        return;
+    }
+    float meanNs = (float)((double)c->windowTotalNs / c->windowSamples);
+    c->windowTotalNs = 0;
+    c->windowSamples = 0;
+
+    int current = c->recommended > 0 ? c->recommended : lowerBound;
+    if (current < lowerBound) {
+        // The user's setting moved since the last recommendation; follow it
+        // up immediately rather than waiting for the next threshold cross
+        current = lowerBound;
+    }
+
+    if (c->samplesSinceChange >= CADENCE_LOCKOUT_SAMPLES) {
+        float ratio = meanNs / (float)budgetNs;
+        if (ratio > CADENCE_RAISE_RATIO && current < CADENCE_MAX_RECOMMENDATION) {
+            current++;
+            c->samplesSinceChange = 0;
+        }
+        else if (ratio < CADENCE_LOWER_RATIO && current > lowerBound) {
+            current--;
+            c->samplesSinceChange = 0;
+        }
+    }
+
+    c->recommended = current;
+}
+
+static void renderVideoFrame(XrCtx* ctx, const float* texMatrix, float separation,
+                             int cadenceLowerBound) {
     // Picks up whatever the depth thread most recently finished, once per
     // frame and before anything below samples a depth slot. The fence that
     // guards it is not waited on here — only a site that actually samples
@@ -8389,6 +8507,13 @@ static void renderVideoFrame(XrCtx* ctx, const float* texMatrix, float separatio
                     ctx->overlayGpuSamples++;
                     if ((long)elapsed > ctx->gpuMaxNs) {
                         ctx->gpuMaxNs = (long)elapsed;
+                    }
+                    // Every plausible warp sample feeds the adaptive cadence
+                    // controller as well, using its own accumulators inside
+                    // cadenceCtrl rather than the two just above.
+                    if (ctx->adaptiveCadenceEnabled && ctx->displayPeriodNs > 0) {
+                        adaptiveCadenceUpdate(&ctx->cadenceCtrl, (long)elapsed,
+                                              (long)ctx->displayPeriodNs, cadenceLowerBound);
                     }
                 }
                 else {
@@ -8976,13 +9101,30 @@ Java_com_limelight_binding_video_XrRenderer_nativeGetWarpGpuMs(JNIEnv* env, jobj
     return ms;
 }
 
+// The adaptive cadence controller's current recommendation, or 0 if it has
+// not formed one yet (still filling its first window) or is turned off.
+// Unlike nativeGetWarpGpuMs() above, reading this must not reset anything:
+// it is polled every frame from the loop rather than once a second from the
+// reporting thread, and the recommendation is meant to persist between
+// windows, not be consumed by the read.
+JNIEXPORT jint JNICALL
+Java_com_limelight_binding_video_XrRenderer_nativeGetAdaptiveCadence(JNIEnv* env, jobject thiz,
+                                                                     jlong handle) {
+    XrCtx* ctx = (XrCtx*)(intptr_t)handle;
+    if (ctx == NULL || !ctx->adaptiveCadenceEnabled) {
+        return 0;
+    }
+    return ctx->cadenceCtrl.recommended;
+}
+
 JNIEXPORT void JNICALL
 Java_com_limelight_binding_video_XrRenderer_nativeEndFrame(JNIEnv* env, jobject thiz, jlong handle,
                                                            jboolean newFrame, jfloatArray texMatrixArr,
                                                            jfloat distance, jfloat quadWidth,
                                                            jfloat curvature, jboolean headLocked,
                                                            jfloat separation, jboolean eyeSwap,
-                                                           jboolean passthrough) {
+                                                           jboolean passthrough,
+                                                           jint cadenceLowerBound) {
     XrCtx* ctx = (XrCtx*)(intptr_t)handle;
 
     ctx->passthrough = passthrough;
@@ -9012,7 +9154,7 @@ Java_com_limelight_binding_video_XrRenderer_nativeEndFrame(JNIEnv* env, jobject 
 
         float texMatrix[16];
         (*env)->GetFloatArrayRegion(env, texMatrixArr, 0, 16, texMatrix);
-        renderVideoFrame(ctx, texMatrix, separation);
+        renderVideoFrame(ctx, texMatrix, separation, cadenceLowerBound);
 
         long elapsed = nowNs() - startNs;
         ctx->statFrames++;


### PR DESCRIPTION
Four changes to the depth path, smallest and most independent first. Each
commit builds on its own, so anything here can be dropped without touching
the rest.

### Fix debug build Proguard config for AGP 9

Unrelated to the rest, but it is what the debug build needed before any of
this could be built. The debug build used to get `-dontoptimize` by way of
`getDefaultProguardFile('proguard-android.txt')`, which AGP 9 no longer
accepts precisely because it carries that flag. Debug now points at
`proguard-android-optimize.txt` with the single flag it actually needed moved
into its own `proguard-rules-debug.pro`, so the debug build keeps doing what
it always did and the release build is untouched.

### Raise thread priorities for render, depth and audio threads

All three ran at the default priority, so they competed with everything else
on equal terms even though two of them have a hard deadline.

Render goes to `URGENT_DISPLAY`. Worth noting that `Thread.setPriority()`
would not have done this — it only changes the JVM's bookkeeping, not the
Linux scheduler, so the call has to go through `Process`.

Depth goes just above the default rather than to `BACKGROUND`, which would
have been the obvious choice and the wrong one: that cpuset is little cores
only on this SoC and would make a model run slower in wall clock, not faster.

The audio thread lives in moonlight-common-c and cannot be reached from Java
before it starts, so the priority is applied from the first decoded sample to
arrive on it, keyed on the tid rather than a flag so a thread recreated mid
stream is not silently left at the default.

### Remove render thread stalls from the depth pipeline

The main one. Two places made the render thread wait on the GPU:

`nativeCaptureDepthInput()` called `glReadPixels()` into a client buffer, so
the render thread blocked until the GPU produced the pixels before it could
submit the frame it still owed the compositor. It now reads into a pixel pack
buffer, which only queues the transfer, and a new `nativeFinishDepthCapture()`
waits on that readback and normalizes it into the model input — on the depth
thread, right before `estimate()` needs it, which is a thread with no frame
deadline to miss.

`nativeUploadDepth()` published with `glFinish()`. That cost the depth thread
nothing, but a finish is also not what the render thread's context needs: the
two are different contexts in the same share group, and a flush alone does not
promise the other context sees the result. The upload is now published behind
a `GLsync` fence that the render thread waits on itself, at the sites that
actually sample the texture. The fence is created before the flush, not after
— a fence left unflushed in the depth thread's queue is one the render thread
may never see satisfied, and it cannot flush that context on our behalf.

Both double buffers become triple buffers, published through a single atomic
release store so the index can never become visible ahead of the fence that
belongs with it. With two slots in a fixed rotation the slot about to be
overwritten was last handed over one rotation ago; with three it is a full
rotation, comfortably longer than any draw call the render thread could still
have in flight against it.

### Adapt depth inference cadence to the GPU frame budget

The cadence was the user's setting and nothing else, so a value that is
comfortable on a quiet scene keeps costing full price when the warp is
already close to running out of frame.

A small controller watches the warp window's GPU time against the real per
frame budget from `xrWaitFrame` — not a hardcoded 11.1 ms, since the refresh
rate is a headset and settings choice of 72, 90 or 120 Hz — and may recommend
a cheaper cadence. It can only ever recommend at or above the user's setting:
cheaper than asked for under load, never dearer. Hysteresis plus a lockout
between changes keeps it from hunting between two cadences and becoming a
stutter source itself.

The decision logic is a pure function of its inputs and the controller's own
state, no GL calls and no reach into the context, so it can be exercised with
synthetic samples and a synthetic budget without a headset.
`debug.moonlight.adaptivecadence` turns it off live, pinning the cadence back
to the user's setting, so the two can be compared on device.

One caveat worth stating plainly, since it affects how you would evaluate
this: the signal is the warp window's GPU time, which does not contain the
inference itself. Contention shows up only indirectly, as inflated warp time
on the frames that overlap a model run, diluted by roughly the cadence. So
the controller stays quiet unless the warp is already near budget. If it never
moves on device, that is the reason — and the right answer would then be a
signal that sees missed frames directly, not a narrower deadband. If you would
rather not carry this one yet, the first three stand without it.

### Testing

Tested successfully on a Quest 3. Each of the four commits was also built
individually with `./gradlew assembleNonRootDebug`, so no commit in the series
is a broken intermediate state.

The new overlay stats line reports the effective cadence, which is the
quickest way to see whether the controller is doing anything on your setup.
